### PR TITLE
The model `qwen-2.5-coder-32b` has been decommissioned and is no longer supported.  

### DIFF
--- a/sqlmap_ai/ai_analyzer.py
+++ b/sqlmap_ai/ai_analyzer.py
@@ -11,7 +11,7 @@ def ai_suggest_next_steps(report, scan_history=None, extracted_data=None):
     structured_info = extract_sqlmap_info(report)
     prompt = create_advanced_prompt(report, structured_info, scan_history, extracted_data)
     print_info("Sending detailed analysis request to Groq AI...")
-    response = get_groq_response(prompt=prompt, model="qwen-2.5-coder-32b")
+    response = get_groq_response(prompt=prompt, model="qwen-qwq-32b")
     if not response:
         print_warning("AI couldn't suggest options, using fallback options")
         return ["--technique=BEU", "--level=3"]

--- a/utils/groq_utils.py
+++ b/utils/groq_utils.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def get_groq_response(
     prompt: str,
-    model: str = "qwen-2.5-coder-32b",
+    model: str = "qwen-qwq-32b",
     role: str = "user",
     max_retries: int = 3,
     retry_delay: int = 2,


### PR DESCRIPTION
The model qwen-2.5-coder-32b has been decommissioned and is no longer supported. This PR updates the system to use the new supported model qwen-qwq-32b as a replacement.

Changes Made:

Replaced references to qwen-2.5-coder-32b with qwen-qwq-32b in the configuration.

Verified compatibility and ensured the updated model integrates correctly with the existing workflow.