### PR TITLE
Changed default model choice of qwen-qwq-32-b to qwen/qwen3-32b

### DIFF
--- a/utils/groq_utils.py
+++ b/utils/groq_utils.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def get_groq_response(
     prompt: str,
-    model: str = "qwen-qwq-32b",
+    model: str = "qwen/qwen3-32b",  # replaced qwen-qwq-32b with qwen/qwen3-32b, per deprecation notice -> https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b
     role: str = "user",
     max_retries: int = 3,
     retry_delay: int = 2,
@@ -26,7 +26,7 @@ def get_groq_response(
 
     Args:
         prompt (str): The prompt to send to the model.
-        model (str): The model to use (defaults to "qwen-qwq-32b").
+        model (str): The model to use (defaults to "qwen/qwen3-32b").
         role (str): The role of the message (e.g., "user", "system", "assistant").
         max_retries (int): Maximum number of retries for failed requests.
         retry_delay (int): Delay (in seconds) between retries.


### PR DESCRIPTION
Fix for issue #3

- Followed guidance from https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b to change qwen-qwq-32b to qwen/qwen3-32b model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default AI model to the latest supported option to align with provider deprecations. No changes to behavior: response handling, retries, and timeouts remain the same.

- Documentation
  - Added a deprecation notice for the previous model with a link to migration guidance.
  - Updated parameter descriptions to reflect the new default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->